### PR TITLE
Bugfix for cases when we don't want headers returned

### DIFF
--- a/ACurlResponse.php
+++ b/ACurlResponse.php
@@ -64,7 +64,7 @@ class ACurlResponse extends CComponent {
 	 * @return CAttributeCollection the headers
 	 */
 	public function getLastHeaders() {
-		if (!$this->headers)
+		if (!$this->_headers)
 			return false;
 		if ($this->getHeaders()->count() > 0) {
 			return $this->getHeaders()->itemAt(0);


### PR DESCRIPTION
Bugfix for cases when we don't want headers returned or no headers are returned by behavior (e.g. save download firectly to file)
