### PR TITLE
Set CURLOPT_POST to true for PUT

### DIFF
--- a/ACurl.php
+++ b/ACurl.php
@@ -140,7 +140,7 @@ class ACurl extends CComponent {
 	public function put($url, $data = array(), $execute = true) {
 		$this->getOptions()->url = $url;
 		$this->getOptions()->postfields = is_string($data) ? $data : http_build_query($data);
-		$this->getOptions()->post = false;
+		$this->getOptions()->post = true;
 		$this->getOptions()->customRequest = "PUT";
 		$this->prepareRequest();
 		return $execute ? $this->exec() : $this;


### PR DESCRIPTION
Hi Charles,

I recently tried to use `PUT` with your YiiCurl extension and found it didn't work unless I made the change in this pull-request.

Event though it seems intuitive that we set `$this->getOptions()->post = false;` for a PUT, we actually need to set it to `true` because we are using the `CURLOPT_POSTFIELDS` option to specify our data and this data is ignored unless `CURLOPT_POST` is true.

Cheers,
Tom
